### PR TITLE
Restrict checking to the matched parameter only

### DIFF
--- a/lib/puppet-lint/plugins/resource_reference_without_title_capital.rb
+++ b/lib/puppet-lint/plugins/resource_reference_without_title_capital.rb
@@ -6,7 +6,7 @@ PuppetLint.new_check(:resource_reference_without_title_capital) do
       }.each do |param_token|
         value_token = param_token.next_code_token
         check = value_token.next_token
-        until check.nil?
+        until resource[:param_tokens].include? check or not resource[:tokens].include? check or check.nil?
           case value_token.next_token.type
           when :CLASSREF
             begin

--- a/lib/puppet-lint/plugins/resource_reference_without_whitespace.rb
+++ b/lib/puppet-lint/plugins/resource_reference_without_whitespace.rb
@@ -6,7 +6,7 @@ PuppetLint.new_check(:resource_reference_without_whitespace) do
       }.each do |param_token|
         value_token = param_token.next_code_token
         check = value_token.next_token
-        until check.nil?
+        until resource[:param_tokens].include? check or not resource[:tokens].include? check or check.nil?
           case value_token.next_token.type
           when :CLASSREF
             begin

--- a/spec/puppet-lint/plugins/resource_reference_without_title_capital_spec.rb
+++ b/spec/puppet-lint/plugins/resource_reference_without_title_capital_spec.rb
@@ -113,7 +113,6 @@ describe 'resource_reference_without_title_capital' do
   end
 
   context 'stay within the parameter context' do
-    let(:msg) { 'whitespace between reference type and title' }
     let(:code) { "file { 'foo': ensure => file, notify => Title['One'],} $var = [ Exec[runsomething] ]" }
 
     it 'should detect no problem' do

--- a/spec/puppet-lint/plugins/resource_reference_without_title_capital_spec.rb
+++ b/spec/puppet-lint/plugins/resource_reference_without_title_capital_spec.rb
@@ -112,4 +112,13 @@ describe 'resource_reference_without_title_capital' do
     end
   end
 
+  context 'stay within the parameter context' do
+    let(:msg) { 'whitespace between reference type and title' }
+    let(:code) { "file { 'foo': ensure => file, notify => Title['One'],} $var = [ Exec[runsomething] ]" }
+
+    it 'should detect no problem' do
+      expect(problems).to have(0).problem
+    end
+  end
+
 end

--- a/spec/puppet-lint/plugins/resource_reference_without_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/resource_reference_without_whitespace_spec.rb
@@ -56,7 +56,6 @@ describe 'resource_reference_without_whitespace' do
   end
 
   context 'stay within the parameter context' do
-    let(:msg) { 'whitespace between reference type and title' }
     let(:code) { "package { 'bar': ensure => installed,}  exec { 'baz': require => Package['bar'],} File { 'foo': ensure => file,}" }
 
     it 'should detect no problem' do

--- a/spec/puppet-lint/plugins/resource_reference_without_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/resource_reference_without_whitespace_spec.rb
@@ -55,4 +55,14 @@ describe 'resource_reference_without_whitespace' do
     end
   end
 
+  context 'stay within the parameter context' do
+    let(:msg) { 'whitespace between reference type and title' }
+    let(:code) { "package { 'bar': ensure => installed,}  exec { 'baz': require => Package['bar'],} File { 'foo': ensure => file,}" }
+
+    it 'should detect no problem' do
+      expect(problems).to have(0).problem
+    end
+ 
+  end
+
 end

--- a/spec/puppet-lint/plugins/resource_reference_without_whitespace_spec.rb
+++ b/spec/puppet-lint/plugins/resource_reference_without_whitespace_spec.rb
@@ -62,7 +62,6 @@ describe 'resource_reference_without_whitespace' do
     it 'should detect no problem' do
       expect(problems).to have(0).problem
     end
- 
   end
 
 end


### PR DESCRIPTION
Previously, the code would walk from the param_token all the way to the end of the file.
This would cause false positives for blocks like:
```
File {
   ensure => file
}
```

or

```
$var = [ Exec[runsomething] ]
```
if they followed a resource block with a matched parameter.